### PR TITLE
><-fix + CONTRIBUT\O\R not serchable fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# IDEs
+.idea/
+.vscode/
+
+# OS
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -3,9 +3,14 @@
 module.exports = function (query) {
   return query
     .replace(/[\*\+\-=~><\"\?^\${}\(\)\:\!\/[\]\\\s]/g, '\\$&') // replace single character special characters
+    .replace(/[><]/g, '') // < and > can’t be escaped at all.
     .replace(/\|\|/g, '\\||') // replace ||
     .replace(/\&\&/g, '\\&&') // replace &&
-    .replace(/AND/g, '\\A\\N\\D') // replace AND
-    .replace(/OR/g, '\\O\\R') // replace OR
-    .replace(/NOT/g, '\\N\\O\\T'); // replace NOT
+      .replace(/(^|\s)AND(\s|$|\\)/g, specSymbToLower) // replace AND
+      .replace(/(^|\s)OR(\s|$|\\)/g, specSymbToLower) // replace OR
+      .replace(/(^|\s)NOT(\s|$|\\)/g, specSymbToLower); // replace NOT
+
+  function specSymbToLower(matched) {
+      return matched.toLowerCase();
+  }
 };

--- a/test/index.js
+++ b/test/index.js
@@ -6,16 +6,27 @@ let sanitize = require('../'),
 describe('Sanitize Query', () => {
   it('escapes all special characters', () => {
     let result = sanitize('+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \\ / AND OR NOT');
-    assert.equal(result, '\\+\\ \\-\\ \\=\\ \\&&\\ \\||\\ \\>\\ \\<\\ \\!\\ \\(\\ \\)\\ \\{\\ \\}\\ \\[\\ \\]\\ \\^\\ \\"\\ \\~\\ \\*\\ \\?\\ \\:\\ \\\\\\ \\/\\ \\A\\N\\D\\ \\O\\R\\ \\N\\O\\T');
+    assert.equal(result, '\\+\\ \\-\\ \\=\\ \\&&\\ \\||\\ \\\\ \\\\ \\!\\ \\(\\ \\)\\ \\{\\ \\}\\ \\[\\ \\]\\ \\^\\ \\"\\ \\~\\ \\*\\ \\?\\ \\:\\ \\\\\\ \\/\\ and\\ or\\ not');
   });
 
   it('escapes all characters in context', () => {
     let result = sanitize('AND there! are? (lots of) char*cters 2 ^escape!');
-    assert.equal(result, '\\A\\N\\D\\ there\\!\\ are\\?\\ \\(lots\\ of\\)\\ char\\*cters\\ 2\\ \\^escape\\!');
+    assert.equal(result, 'and\\ there\\!\\ are\\?\\ \\(lots\\ of\\)\\ char\\*cters\\ 2\\ \\^escape\\!');
   });
 
   it('escapes repeated special characters', () => {
     let result = sanitize('&& || && || > < ! > < ! AND OR NOT NOT OR AND');
-    assert.equal(result, '\\&&\\ \\||\\ \\&&\\ \\||\\ \\>\\ \\<\\ \\!\\ \\>\\ \\<\\ \\!\\ \\A\\N\\D\\ \\O\\R\\ \\N\\O\\T\\ \\N\\O\\T\\ \\O\\R\\ \\A\\N\\D');
+    assert.equal(result, '\\&&\\ \\||\\ \\&&\\ \\||\\ \\\\ \\\\ \\!\\ \\\\ \\\\ \\!\\ and\\ or\\ not\\ not\\ or\\ and');
+  });
+
+  it('handles special chars inside words', () => {
+      let contributor = sanitize('CONTRIBUTOR');
+      assert.equal(contributor, 'CONTRIBUTOR');
+
+      let organize = sanitize('ORGANIZE');
+      assert.equal(organize, 'ORGANIZE');
+
+      let notify = sanitize(' NOTIFY');
+      assert.equal(notify, '\\ NOTIFY');
   });
 });


### PR DESCRIPTION
According to [https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html](url)

> < and > can’t be escaped at all. The only way to prevent them from attempting to create a range query is to remove them from the query string entirely.

Plus AND-OR-NOT updates.